### PR TITLE
Allowing AnyOfField or OneOfField to use schema

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -373,6 +373,7 @@ function SchemaFieldRender(props) {
           baseType={schema.type}
           registry={registry}
           safeRenderCompletion={props.safeRenderCompletion}
+          schema={schema}
           uiSchema={uiSchema}
         />
       )}
@@ -391,6 +392,7 @@ function SchemaFieldRender(props) {
           baseType={schema.type}
           registry={registry}
           safeRenderCompletion={props.safeRenderCompletion}
+          schema={schema}
           uiSchema={uiSchema}
         />
       )}


### PR DESCRIPTION
### Reasons for making this change

I have a use case where I'd like to be able to define an anyOf in the schema, but still render items from the schema. This should be allowable if I create my own AnyOfField, but currently SchemaField doesn't pass through my schema. This should at least open up the ability to handle an AnyOfField different, should someone choose to.
